### PR TITLE
scan for treebanks rather than reading json file

### DIFF
--- a/barchybrid/src/parser.py
+++ b/barchybrid/src/parser.py
@@ -163,6 +163,9 @@ if __name__ == '__main__':
 if using UD. If not specified need to specify trainfile at least. When used in combination with \
 --multiling, trains a common parser for all languages. Otherwise, train monolingual parsers for \
 each")
+    group.add_option("--treebanks-from-json", action="store_true", default=False,
+        help='Read available treebanks from src/utils/ud_iso.json (or metadata.json in shared \
+task mode) rather than scanning datadir.')
     group.add_option("--trainfile", metavar="FILE", help="Annotated CONLL(U) train file")
     group.add_option("--devfile", metavar="FILE", help="Annotated CONLL(U) dev file")
     group.add_option("--testfile", metavar="FILE", help="Annotated CONLL(U) test file")

--- a/barchybrid/src/utils.py
+++ b/barchybrid/src/utils.py
@@ -169,9 +169,26 @@ def vocab(conll_path, path_is_dir=False):
             langCounter.keys() if langCounter else None, charsCount.keys())
 
 
-def conll_dir_to_list(languages, data_dir,shared_task=False, shared_task_data_dir=None):
+def conll_dir_to_list(
+    languages, data_dir,
+    shared_task=False,
+    shared_task_data_dir=None,
+    treebanks_from_json=True,
+):
     import json
-    if shared_task:
+    if not treebanks_from_json:
+        treebank_metadata = []
+        for entry in os.listdir(data_dir):
+            candidate_dir = os.path.join(data_dir, entry)
+            if os.path.isdir(candidate_dir):
+                for filename in os.listdir(candidate_dir):
+                    fields = filename.split('-ud-')
+                    if len(fields) == 2 and fields[1] == 'train.conllu':
+                        treebank_metadata.append((
+                            entry.decode('utf-8'),
+                            fields[0].decode('utf-8')
+                        ))
+    elif shared_task:
         metadataFile = shared_task_data_dir +'/metadata.json'
         metadata = codecs.open(metadataFile, 'r',encoding='utf-8')
         json_str = metadata.read()
@@ -181,9 +198,9 @@ def conll_dir_to_list(languages, data_dir,shared_task=False, shared_task_data_di
         json_str = ud_iso_file.read()
         iso_dict = json.loads(json_str)
         treebank_metadata = iso_dict.items()
-    json_treebanks= [UDtreebank(treebank_info,data_dir,shared_task, shared_task_data_dir) \
+    ud_treebanks = [UDtreebank(treebank_info, data_dir, shared_task, shared_task_data_dir) \
             for treebank_info in treebank_metadata ]
-    return json_treebanks
+    return ud_treebanks
 
 def read_conll_dir(languages,filetype,maxSize=-1):
     #print "Max size for each corpus: ", maxSize


### PR DESCRIPTION
Add support for reading the list of supported iso_ids and the long folder names directly from the treebank datadir rather than requiring the user to maintain a json file. Make this the default and provide an option to request the old behaviour.