### PR TITLE
Parser uses the same root token object for the whole treebank

### DIFF
--- a/barchybrid/src/utils.py
+++ b/barchybrid/src/utils.py
@@ -264,6 +264,14 @@ def read_conll_dir(treebanks,filetype,maxSize=-1,char_map={}):
     elif filetype == "test":
         return chain(*(read_conll(treebank.testfile, treebank.iso_id, treebank.proxy_tbank, train=False, char_map=char_map) for treebank in treebanks))
 
+
+def generate_root_token():
+    return ConllEntry(0, '*root*', '*root*', 'ROOT-POS', 'ROOT-CPOS', '_', -1,
+        'rroot', '_', '_',treebank_id=treebank_id, proxy_tbank=proxy_tbank,
+        language=language
+    )
+
+
 def read_conll(filename, treebank_id=None, proxy_tbank=None, maxSize=-1, hard_lim=False, vocab_prep=False, drop_nproj=False, train=True, char_map={}):
     # hard lim means capping the corpus size across the whole training procedure
     # soft lim means using a sample of the whole corpus at each epoch
@@ -278,9 +286,7 @@ def read_conll(filename, treebank_id=None, proxy_tbank=None, maxSize=-1, hard_li
         language = get_lang_from_tbank_id(treebank_id)
     else:
         language = None
-    root = ConllEntry(0, '*root*', '*root*', 'ROOT-POS', 'ROOT-CPOS', '_', -1, 'rroot',
-        '_', '_',treebank_id=treebank_id, proxy_tbank=proxy_tbank,language=language)
-    tokens = [root]
+    tokens = [generate_root_token()]
     yield_count = 0
     if maxSize > 0 and not hard_lim:
         sents = []
@@ -313,7 +319,7 @@ def read_conll(filename, treebank_id=None, proxy_tbank=None, maxSize=-1, hard_li
                 else:
                     #print 'Non-projective sentence dropped'
                     dropped += 1
-            tokens = [root]
+            tokens = [generate_root_token()]
         else:
             if line[0] == '#' or '-' in tok[0] or '.' in tok[0]: # a comment line, add to tokens as is
                 tokens.append(line.strip())


### PR DESCRIPTION
When reading in the treebank, the same root token object is used for all the sentences. The result is that the `rdeps` property of the root token is continuously overwritten as the value is calculated for each sentence individually.

I propose generating a new object for every sentence to avoid this. 

Comparing with my own implementation, the only visible difference of this bug is that the cost of left-arc is off by one (e.g. 2 instead of 3) because of this line: 
https://github.com/jgontrum/uuparser-with-elmo/blob/376c6b2bebc8c0b6c3ddb363e7a28d80e64a95c5/barchybrid/src/arc_hybrid.py#L160

However, this only occurs when the cost is at least one and the only use of the left-arc cost is to check that it is greater than zero. I therefore think that it should not affect the performance of the parser.
