### PR TITLE
Explicitly set dynet mem and seed

### DIFF
--- a/uuparser/parser.py
+++ b/uuparser/parser.py
@@ -1,6 +1,7 @@
 from optparse import OptionParser, OptionGroup
 from uuparser.options_manager import OptionsManager
 import pickle, os, time, sys, copy, itertools, re, random
+import dynet_config
 from shutil import copyfile
 
 from uuparser import utils
@@ -272,6 +273,7 @@ each")
 
     # really important to do this before anything else to make experiments reproducible
     utils.set_seeds(options)
+    dynet_config.set(mem=options.dynet_mem, random_seed=options.dynet_seed)
 
     om = OptionsManager(options)
     experiments = om.create_experiment_list(options) # list of namedtuples


### PR DESCRIPTION
Currently, setting dynet random seed and max memory relies on dynet parsing `sys.argv` to obtain them, but they are still added in the command line argument parser (to avoid erroring). The effect is that, counterintuitively, the command line arguments as defined in the argument parser are actually not used, including their default values (for instance, in the current state, changing `--dynet-mem` default value to be `2048` would have no effect).

I propose to change this by explicitly setting dynet config in `parser.main`, it does not change anything to how the parser run by itself, but it will make it easier to modify it in the future and to embed it in another application.