### PR TITLE
Fix resuming training

### DIFF
--- a/uuparser/parser.py
+++ b/uuparser/parser.py
@@ -35,7 +35,7 @@ def run(experiment,options):
         else:  #continue
             if options.continueParams:
                 paramsfile = options.continueParams
-            with open(paramsfile, 'r') as paramsfp:
+            with open(paramsfile, 'rb') as paramsfp:
                 stored_vocab, stored_options = pickle.load(paramsfp)
                 logger.debug('Initializing the model:')
                 parser = Parser(stored_vocab, stored_options)


### PR DESCRIPTION
Resuming training from pickled parameters was not possible (#25 ) because we tried to open the file in text instead of binary mode, this PR fixes that.